### PR TITLE
Implement fluent interfaces on SVG object setters

### DIFF
--- a/src/nodes/SVGNode.php
+++ b/src/nodes/SVGNode.php
@@ -21,10 +21,12 @@ abstract class SVGNode {
 
     public function setStyle($name, $value) {
         $this->styles[$name] = $value;
+        return $this;
     }
 
     public function removeStyle($name) {
         unset($this->styles[$name]);
+        return $this;
     }
 
 

--- a/src/nodes/shapes/SVGCircle.php
+++ b/src/nodes/shapes/SVGCircle.php
@@ -22,6 +22,7 @@ class SVGCircle extends SVGNode {
 
     public function setCenterX($cx) {
         $this->cx = $cx;
+        return $this;
     }
 
 
@@ -32,6 +33,7 @@ class SVGCircle extends SVGNode {
 
     public function setCenterY($cy) {
         $this->cy = $cy;
+        return $this;
     }
 
 
@@ -44,6 +46,7 @@ class SVGCircle extends SVGNode {
 
     public function setRadius($r) {
         $this->r = $r;
+        return $this;
     }
 
 

--- a/src/nodes/shapes/SVGEllipse.php
+++ b/src/nodes/shapes/SVGEllipse.php
@@ -23,6 +23,7 @@ class SVGEllipse extends SVGNode {
 
     public function setCenterX($cx) {
         $this->cx = $cx;
+        return $this;
     }
 
 
@@ -33,6 +34,7 @@ class SVGEllipse extends SVGNode {
 
     public function setCenterY($cy) {
         $this->cy = $cy;
+        return $this;
     }
 
 
@@ -45,6 +47,7 @@ class SVGEllipse extends SVGNode {
 
     public function setRadiusX($rx) {
         $this->rx = $rx;
+        return $this;
     }
 
 
@@ -55,6 +58,7 @@ class SVGEllipse extends SVGNode {
 
     public function setRadiusY($ry) {
         $this->ry = $ry;
+        return $this;
     }
 
 

--- a/src/nodes/shapes/SVGLine.php
+++ b/src/nodes/shapes/SVGLine.php
@@ -23,6 +23,7 @@ class SVGLine extends SVGNode {
 
     public function setX1($x1) {
         $this->x1 = $x1;
+        return $this;
     }
 
 
@@ -33,6 +34,7 @@ class SVGLine extends SVGNode {
 
     public function setY1($y1) {
         $this->y1 = $y1;
+        return $this;
     }
 
 
@@ -45,6 +47,7 @@ class SVGLine extends SVGNode {
 
     public function setX2($x2) {
         $this->x2 = $x2;
+        return $this;
     }
 
 
@@ -55,6 +58,7 @@ class SVGLine extends SVGNode {
 
     public function setY2($y2) {
         $this->y2 = $y2;
+        return $this;
     }
 
 

--- a/src/nodes/shapes/SVGPolygon.php
+++ b/src/nodes/shapes/SVGPolygon.php
@@ -21,11 +21,13 @@ class SVGPolygon extends SVGNode {
         }
 
         $this->points[] = $a;
+        return $this;
 
     }
 
     public function removePoint($index) {
         array_splice($this->points, $index, 1);
+        return $this;
     }
 
 
@@ -48,6 +50,7 @@ class SVGPolygon extends SVGNode {
 
     public function setPoint($index, $point) {
         $this->points[$index] = $point;
+        return $this;
     }
 
 

--- a/src/nodes/shapes/SVGPolyline.php
+++ b/src/nodes/shapes/SVGPolyline.php
@@ -26,6 +26,7 @@ class SVGPolyline extends SVGNode {
 
     public function removePoint($index) {
         array_splice($this->points, $index, 1);
+        return $this;
     }
 
 
@@ -48,6 +49,7 @@ class SVGPolyline extends SVGNode {
 
     public function setPoint($index, $point) {
         $this->points[$index] = $point;
+        return $this;
     }
 
 

--- a/src/nodes/shapes/SVGRect.php
+++ b/src/nodes/shapes/SVGRect.php
@@ -23,6 +23,7 @@ class SVGRect extends SVGNode {
 
     public function setX($x) {
         $this->x = $x;
+        return $this;
     }
 
 
@@ -33,6 +34,7 @@ class SVGRect extends SVGNode {
 
     public function setY($y) {
         $this->y = $y;
+        return $this;
     }
 
 
@@ -45,6 +47,7 @@ class SVGRect extends SVGNode {
 
     public function setWidth($width) {
         $this->width = $width;
+        return $this;
     }
 
 
@@ -55,6 +58,7 @@ class SVGRect extends SVGNode {
 
     public function setHeight($height) {
         $this->height = $height;
+        return $this;
     }
 
 

--- a/src/nodes/structures/SVGDocumentFragment.php
+++ b/src/nodes/structures/SVGDocumentFragment.php
@@ -47,6 +47,7 @@ class SVGDocumentFragment extends SVGNodeContainer {
 
     public function setWidth($width) {
         $this->width = $width;
+        return $this;
     }
 
 
@@ -57,6 +58,7 @@ class SVGDocumentFragment extends SVGNodeContainer {
 
     public function setHeight($height) {
         $this->height = $height;
+        return $this;
     }
 
 


### PR DESCRIPTION
This merge request just adds a `return $this` to SVG node property setters. This lets one chain calls in a fluent style, e.g. I can now write:

```php
$doc->addChild(
     (new SVGCircle(200, 200, 10))
         ->setStyle('fill-opacity', 0.01)
         ->setStyle('stroke-width', 1)
         ->setStyle('stroke', 'currentColor')
);
```

instead of the more verbose
```php
$circle = new SVGCircle(200, 200, 10);
$circle->setStyle('fill-opacity', 0.01);
$circle->setStyle('stroke-width', 1);
$circle->setStyle('stroke', 'currentColor');

$doc->addChild($circle);
```

Since node property setters don't currently return anything, this will not break any code using the current API, which will continue to function unaffected, while enabling the option to use a fluent interface if desired.
                                                                     `