### PR TITLE
Special prop's backed by `SVGNode::attributes` (simpler read/write)

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -25,18 +25,20 @@ abstract class SVGNode
 
     /**
      * Factory function for this class, which accepts an associative array of
-     * attributes instead of parameters in the exact order (like `__construct`).
+     * strings instead of parameters in the correct order (like `__construct`).
+     *
+     * By default, simply invokes the constructor with no arguments. Subclasses
+     * may choose to override this if they require special behavior.
      *
      * @param string[] $attrs The attribute array (or array-like object; e.g. \SimpleXMLElement).
      *
      * @return static A new instance of the class this was called on.
-     * @throws \Exception If not overridden by subclass (should never occurr).
      *
      * @SuppressWarnings("unused")
      */
     public static function constructFromAttributes($attrs)
     {
-        throw new \Exception(get_called_class().' does not implement '.__FUNCTION__.'!');
+        return new static();
     }
 
 
@@ -150,6 +152,25 @@ abstract class SVGNode
     {
         $this->attributes[$name] = $value;
         return $this;
+    }
+
+    /**
+     * Defines an attribute, if and only if a non-null value is given; otherwise
+     * behaves like `setAttribute(...)`.
+     *
+     * This is useful for initializing attributes in constructors.
+     *
+     * @param string      $name  The name of the attribute to set.
+     * @param string|null $value The new attribute value.
+     *
+     * @return $this This node instance, for call chaining.
+     */
+    protected function setAttributeOptional($name, $value = null)
+    {
+        if (!isset($value)) {
+            return;
+        }
+        return $this->setAttribute($name, $value);
     }
 
     /**

--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -10,8 +10,6 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 abstract class SVGNode
 {
-    /** @var string $name The tag name. */
-    private $name;
     /** @var SVGNodeContainer $parent The parent node. */
     protected $parent;
     /** @var string[] $styles This node's set of explicit style declarations. */
@@ -19,12 +17,8 @@ abstract class SVGNode
     /** @var string[] $attributes This node's set of attributes. */
     protected $attributes;
 
-    /**
-     * @param string $name The tag name.
-     */
-    public function __construct($name)
+    public function __construct()
     {
-        $this->name       = $name;
         $this->styles     = array();
         $this->attributes = array();
     }
@@ -52,7 +46,7 @@ abstract class SVGNode
      */
     public function getName()
     {
-        return $this->name;
+        return static::TAG_NAME;
     }
 
     /**

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -12,12 +12,9 @@ abstract class SVGNodeContainer extends SVGNode
     /** @var SVGNode[] $children This node's child nodes. */
     protected $children;
 
-    /**
-     * @param string $name The tag name.
-     */
-    public function __construct($name)
+    public function __construct()
     {
-        parent::__construct($name);
+        parent::__construct();
 
         $this->children = array();
     }

--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -11,6 +11,8 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGCircle extends SVGNode
 {
+    const TAG_NAME = 'circle';
+
     /**
      * @var string $cx The center's x coordinate.
      * @var string $cy The center's y coordinate.
@@ -25,7 +27,7 @@ class SVGCircle extends SVGNode
      */
     public function __construct($cx, $cy, $r)
     {
-        parent::__construct('circle');
+        parent::__construct();
 
         $this->cx = $cx;
         $this->cy = $cy;

--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -14,33 +14,17 @@ class SVGCircle extends SVGNode
     const TAG_NAME = 'circle';
 
     /**
-     * @var string $cx The center's x coordinate.
-     * @var string $cy The center's y coordinate.
-     * @var string $rx The radius.
+     * @param string|null $cx The center's x coordinate.
+     * @param string|null $cy The center's y coordinate.
+     * @param string|null $r  The radius.
      */
-    private $cx, $cy, $r;
-
-    /**
-     * @param string $cx The center's x coordinate.
-     * @param string $cy The center's y coordinate.
-     * @param string $rx The radius.
-     */
-    public function __construct($cx, $cy, $r)
+    public function __construct($cx = null, $cy = null, $r = null)
     {
         parent::__construct();
 
-        $this->cx = $cx;
-        $this->cy = $cy;
-        $this->r  = $r;
-    }
-
-    public static function constructFromAttributes($attrs)
-    {
-        $cx = isset($attrs['cx']) ? $attrs['cx'] : '';
-        $cy = isset($attrs['cy']) ? $attrs['cy'] : '';
-        $r  = isset($attrs['r']) ? $attrs['r'] : '';
-
-        return new self($cx, $cy, $r);
+        $this->setAttributeOptional('cx', $cx);
+        $this->setAttributeOptional('cy', $cy);
+        $this->setAttributeOptional('r', $r);
     }
 
 
@@ -50,7 +34,7 @@ class SVGCircle extends SVGNode
      */
     public function getCenterX()
     {
-        return $this->cx;
+        return $this->getAttribute('cx');
     }
 
     /**
@@ -62,8 +46,7 @@ class SVGCircle extends SVGNode
      */
     public function setCenterX($cx)
     {
-        $this->cx = $cx;
-        return $this;
+        return $this->setAttribute('cx', $cx);
     }
 
     /**
@@ -71,7 +54,7 @@ class SVGCircle extends SVGNode
      */
     public function getCenterY()
     {
-        return $this->cy;
+        return $this->getAttribute('cy');
     }
 
     /**
@@ -83,8 +66,7 @@ class SVGCircle extends SVGNode
      */
     public function setCenterY($cy)
     {
-        $this->cy = $cy;
-        return $this;
+        return $this->setAttribute('cy', $cy);
     }
 
 
@@ -94,7 +76,7 @@ class SVGCircle extends SVGNode
      */
     public function getRadius()
     {
-        return $this->r;
+        return $this->getAttribute('r');
     }
 
     /**
@@ -106,32 +88,19 @@ class SVGCircle extends SVGNode
      */
     public function setRadius($r)
     {
-        $this->r = $r;
-        return $this;
-    }
-
-
-
-    public function getSerializableAttributes()
-    {
-        $attrs = parent::getSerializableAttributes();
-
-        $attrs['cx'] = $this->cx;
-        $attrs['cy'] = $this->cy;
-        $attrs['r']  = $this->r;
-
-        return $attrs;
+        return $this->setAttribute('r', $r);
     }
 
 
 
     public function rasterize(SVGRasterizer $rasterizer)
     {
+        $r = $this->getRadius();
         $rasterizer->render('ellipse', array(
-            'cx'    => $this->cx,
-            'cy'    => $this->cy,
-            'rx'    => $this->r,
-            'ry'    => $this->r,
+            'cx'    => $this->getCenterX(),
+            'cy'    => $this->getCenterY(),
+            'rx'    => $r,
+            'ry'    => $r,
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -14,41 +14,19 @@ class SVGEllipse extends SVGNode
     const TAG_NAME = 'ellipse';
 
     /**
-     * @var string $cx The center's x coordinate.
-     * @var string $cy The center's y coordinate.
-     * @var string $rx The radius along the x-axis.
-     * @var string $ry The radius along the y-axis.
+     * @param string|null $cx The center's x coordinate.
+     * @param string|null $cy The center's y coordinate.
+     * @param string|null $rx The radius along the x-axis.
+     * @param string|null $ry The radius along the y-axis.
      */
-    private $cx, $cy, $rx, $ry;
-
-    /**
-     * @param string $cx The center's x coordinate.
-     * @param string $cy The center's y coordinate.
-     * @param string $rx The radius along the x-axis.
-     * @param string $ry The radius along the y-axis.
-     */
-    public function __construct($cx, $cy, $rx, $ry)
+    public function __construct($cx = null, $cy = null, $rx = null, $ry = null)
     {
         parent::__construct();
 
-        $this->cx = $cx;
-        $this->cy = $cy;
-        $this->rx = $rx;
-        $this->ry = $ry;
-    }
-
-    /**
-     * @inheritDoc
-     * @SuppressWarnings("NPath")
-     */
-    public static function constructFromAttributes($attrs)
-    {
-        $cx = isset($attrs['cx']) ? $attrs['cx'] : '';
-        $cy = isset($attrs['cy']) ? $attrs['cy'] : '';
-        $rx = isset($attrs['rx']) ? $attrs['rx'] : '';
-        $ry = isset($attrs['ry']) ? $attrs['ry'] : '';
-
-        return new self($cx, $cy, $rx, $ry);
+        $this->setAttributeOptional('cx', $cx);
+        $this->setAttributeOptional('cy', $cy);
+        $this->setAttributeOptional('rx', $rx);
+        $this->setAttributeOptional('ry', $ry);
     }
 
 
@@ -58,7 +36,7 @@ class SVGEllipse extends SVGNode
      */
     public function getCenterX()
     {
-        return $this->cx;
+        return $this->getAttribute('cx');
     }
 
     /**
@@ -70,8 +48,7 @@ class SVGEllipse extends SVGNode
      */
     public function setCenterX($cx)
     {
-        $this->cx = $cx;
-        return $this;
+        return $this->setAttribute('cx', $cx);
     }
 
     /**
@@ -79,7 +56,7 @@ class SVGEllipse extends SVGNode
      */
     public function getCenterY()
     {
-        return $this->cy;
+        return $this->getAttribute('cy');
     }
 
     /**
@@ -91,8 +68,7 @@ class SVGEllipse extends SVGNode
      */
     public function setCenterY($cy)
     {
-        $this->cy = $cy;
-        return $this;
+        return $this->setAttribute('cy', $cy);
     }
 
 
@@ -102,7 +78,7 @@ class SVGEllipse extends SVGNode
      */
     public function getRadiusX()
     {
-        return $this->rx;
+        return $this->getAttribute('rx');
     }
 
     /**
@@ -114,8 +90,7 @@ class SVGEllipse extends SVGNode
      */
     public function setRadiusX($rx)
     {
-        $this->rx = $rx;
-        return $this;
+        return $this->setAttribute('rx', $rx);
     }
 
     /**
@@ -123,7 +98,7 @@ class SVGEllipse extends SVGNode
      */
     public function getRadiusY()
     {
-        return $this->ry;
+        return $this->getAttribute('ry');
     }
 
     /**
@@ -135,22 +110,7 @@ class SVGEllipse extends SVGNode
      */
     public function setRadiusY($ry)
     {
-        $this->ry = $ry;
-        return $this;
-    }
-
-
-
-    public function getSerializableAttributes()
-    {
-        $attrs = parent::getSerializableAttributes();
-
-        $attrs['cx'] = $this->cx;
-        $attrs['cy'] = $this->cy;
-        $attrs['rx'] = $this->rx;
-        $attrs['ry'] = $this->ry;
-
-        return $attrs;
+        return $this->setAttribute('ry', $ry);
     }
 
 
@@ -158,10 +118,10 @@ class SVGEllipse extends SVGNode
     public function rasterize(SVGRasterizer $rasterizer)
     {
         $rasterizer->render('ellipse', array(
-            'cx'    => $this->cx,
-            'cy'    => $this->cy,
-            'rx'    => $this->rx,
-            'ry'    => $this->ry,
+            'cx'    => $this->getCenterX(),
+            'cy'    => $this->getCenterY(),
+            'rx'    => $this->getRadiusX(),
+            'ry'    => $this->getRadiusY(),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -11,6 +11,8 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGEllipse extends SVGNode
 {
+    const TAG_NAME = 'ellipse';
+
     /**
      * @var string $cx The center's x coordinate.
      * @var string $cy The center's y coordinate.
@@ -27,7 +29,7 @@ class SVGEllipse extends SVGNode
      */
     public function __construct($cx, $cy, $rx, $ry)
     {
-        parent::__construct('ellipse');
+        parent::__construct();
 
         $this->cx = $cx;
         $this->cy = $cy;

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -14,41 +14,19 @@ class SVGLine extends SVGNode
     const TAG_NAME = 'line';
 
     /**
-     * @var string $x1 The first point's x coordinate.
-     * @var string $y1 The first point's y coordinate.
-     * @var string $x2 The second point's x coordinate.
-     * @var string $y2 The second point's y coordinate.
+     * @param string|null $x1 The first point's x coordinate.
+     * @param string|null $y1 The first point's y coordinate.
+     * @param string|null $x2 The second point's x coordinate.
+     * @param string|null $y2 The second point's y coordinate.
      */
-    private $x1, $y1, $x2, $y2;
-
-    /**
-     * @param string $x1 The first point's x coordinate.
-     * @param string $y1 The first point's y coordinate.
-     * @param string $x2 The second point's x coordinate.
-     * @param string $y2 The second point's y coordinate.
-     */
-    public function __construct($x1, $y1, $x2, $y2)
+    public function __construct($x1 = null, $y1 = null, $x2 = null, $y2 = null)
     {
         parent::__construct();
 
-        $this->x1 = $x1;
-        $this->y1 = $y1;
-        $this->x2 = $x2;
-        $this->y2 = $y2;
-    }
-
-    /**
-     * @inheritDoc
-     * @SuppressWarnings("NPath")
-     */
-    public static function constructFromAttributes($attrs)
-    {
-        $x1 = isset($attrs['x1']) ? $attrs['x1'] : '';
-        $y1 = isset($attrs['y1']) ? $attrs['y1'] : '';
-        $x2 = isset($attrs['x2']) ? $attrs['x2'] : '';
-        $y2 = isset($attrs['y2']) ? $attrs['y2'] : '';
-
-        return new self($x1, $y1, $x2, $y2);
+        $this->setAttributeOptional('x1', $x1);
+        $this->setAttributeOptional('y1', $y1);
+        $this->setAttributeOptional('x2', $x2);
+        $this->setAttributeOptional('y2', $y2);
     }
 
 
@@ -58,7 +36,7 @@ class SVGLine extends SVGNode
      */
     public function getX1()
     {
-        return $this->x1;
+        return $this->getAttribute('x1');
     }
 
     /**
@@ -70,8 +48,7 @@ class SVGLine extends SVGNode
      */
     public function setX1($x1)
     {
-        $this->x1 = $x1;
-        return $this;
+        return $this->setAttribute('x1', $x1);
     }
 
     /**
@@ -79,7 +56,7 @@ class SVGLine extends SVGNode
      */
     public function getY1()
     {
-        return $this->y1;
+        return $this->getAttribute('y1');
     }
 
     /**
@@ -91,8 +68,7 @@ class SVGLine extends SVGNode
      */
     public function setY1($y1)
     {
-        $this->y1 = $y1;
-        return $this;
+        return $this->setAttribute('y1', $y1);
     }
 
 
@@ -102,7 +78,7 @@ class SVGLine extends SVGNode
      */
     public function getX2()
     {
-        return $this->x2;
+        return $this->getAttribute('x2');
     }
 
     /**
@@ -114,8 +90,7 @@ class SVGLine extends SVGNode
      */
     public function setX2($x2)
     {
-        $this->x2 = $x2;
-        return $this;
+        return $this->setAttribute('x2', $x2);
     }
 
     /**
@@ -123,7 +98,7 @@ class SVGLine extends SVGNode
      */
     public function getY2()
     {
-        return $this->y2;
+        return $this->getAttribute('y2');
     }
 
     /**
@@ -135,22 +110,7 @@ class SVGLine extends SVGNode
      */
     public function setY2($y2)
     {
-        $this->y2 = $y2;
-        return $this;
-    }
-
-
-
-    public function getSerializableAttributes()
-    {
-        $attrs = parent::getSerializableAttributes();
-
-        $attrs['x1'] = $this->x1;
-        $attrs['y1'] = $this->y1;
-        $attrs['x2'] = $this->x2;
-        $attrs['y2'] = $this->y2;
-
-        return $attrs;
+        return $this->setAttribute('y2', $y2);
     }
 
 
@@ -158,10 +118,10 @@ class SVGLine extends SVGNode
     public function rasterize(SVGRasterizer $rasterizer)
     {
         $rasterizer->render('line', array(
-            'x1'    => $this->x1,
-            'y1'    => $this->y1,
-            'x2'    => $this->x2,
-            'y2'    => $this->y2,
+            'x1'    => $this->getX1(),
+            'y1'    => $this->getY1(),
+            'x2'    => $this->getX2(),
+            'y2'    => $this->getY2(),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -11,6 +11,8 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGLine extends SVGNode
 {
+    const TAG_NAME = 'line';
+
     /**
      * @var string $x1 The first point's x coordinate.
      * @var string $y1 The first point's y coordinate.
@@ -27,7 +29,7 @@ class SVGLine extends SVGNode
      */
     public function __construct($x1, $y1, $x2, $y2)
     {
-        parent::__construct('line');
+        parent::__construct();
 
         $this->x1 = $x1;
         $this->y1 = $y1;

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -42,7 +42,7 @@ class SVGLine extends SVGNode
     /**
      * Sets the first point's x coordinate.
      *
-     * @param string The new coordinate.
+     * @param string $x1 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
@@ -62,7 +62,7 @@ class SVGLine extends SVGNode
     /**
      * Sets the first point's y coordinate.
      *
-     * @param string The new coordinate.
+     * @param string $y1 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
@@ -84,7 +84,7 @@ class SVGLine extends SVGNode
     /**
      * Sets the second point's x coordinate.
      *
-     * @param string The new coordinate.
+     * @param string $x2 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
@@ -104,7 +104,7 @@ class SVGLine extends SVGNode
     /**
      * Sets the second point's y coordinate.
      *
-     * @param string The new coordinate.
+     * @param string $y2 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -19,7 +19,7 @@ class SVGPath extends SVGNode
     {
         parent::__construct();
 
-        $this->setAttributeOptional($d);
+        $this->setAttributeOptional('d', $d);
     }
 
     /**

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -12,42 +12,23 @@ class SVGPath extends SVGNode
 {
     const TAG_NAME = 'path';
 
-    /** @var string $d The path description. */
-    private $d;
-
     /**
-     * @param string $d The path description.
+     * @param string|null $d The path description.
      */
-    public function __construct($d)
+    public function __construct($d = null)
     {
         parent::__construct();
 
-        $this->d = $d;
-    }
-
-    public static function constructFromAttributes($attrs)
-    {
-        $d = isset($attrs['d']) ? $attrs['d'] : '';
-
-        return new self($d);
-    }
-
-
-
-    public function getSerializableAttributes()
-    {
-        $attrs = parent::getSerializableAttributes();
-
-        $attrs['d'] = $this->d;
-
-        return $attrs;
+        $this->setAttributeOptional($d);
     }
 
 
 
     public function rasterize(SVGRasterizer $rasterizer)
     {
-        $commands = $rasterizer->getPathParser()->parse($this->d);
+        $d = $this->getAttribute('d');
+
+        $commands = $rasterizer->getPathParser()->parse($d);
         $subpaths = $rasterizer->getPathApproximator()->approximate($commands);
 
         foreach ($subpaths as $subpath) {

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -10,6 +10,8 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGPath extends SVGNode
 {
+    const TAG_NAME = 'path';
+
     /** @var string $d The path description. */
     private $d;
 
@@ -18,7 +20,7 @@ class SVGPath extends SVGNode
      */
     public function __construct($d)
     {
-        parent::__construct('path');
+        parent::__construct();
 
         $this->d = $d;
     }

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -22,11 +22,32 @@ class SVGPath extends SVGNode
         $this->setAttributeOptional($d);
     }
 
+    /**
+     * @return string The path description string.
+     */
+    public function getDescription()
+    {
+        return $this->getAttribute('d');
+    }
 
+    /**
+     * Sets the path description string.
+     *
+     * @param string $d The new description.
+     *
+     * @return $this This node instance, for call chaining.
+     */
+    public function setDescription($d)
+    {
+        return $this->setAttribute('d', $d);
+    }
 
     public function rasterize(SVGRasterizer $rasterizer)
     {
-        $d = $this->getAttribute('d');
+        $d = $this->getDescription();
+        if (!isset($d)) {
+            return;
+        }
 
         $commands = $rasterizer->getPathParser()->parse($d);
         $subpaths = $rasterizer->getPathApproximator()->approximate($commands);

--- a/src/Nodes/Shapes/SVGPolygon.php
+++ b/src/Nodes/Shapes/SVGPolygon.php
@@ -10,12 +10,14 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGPolygon extends SVGPolygonalShape
 {
+    const TAG_NAME = 'polygon';
+
     /**
      * @param array[] $points Array of points (float 2-tuples).
      */
     public function __construct($points = array())
     {
-        parent::__construct('polygon', $points);
+        parent::__construct($points);
     }
 
     public function rasterize(SVGRasterizer $rasterizer)

--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -14,12 +14,11 @@ abstract class SVGPolygonalShape extends SVGNode
     private $points;
 
     /**
-     * @param string  $name   The tag name.
      * @param array[] $points Array of points (float 2-tuples).
      */
-    public function __construct($name, $points)
+    public function __construct($points)
     {
-        parent::__construct($name);
+        parent::__construct();
 
         $this->points = $points;
     }

--- a/src/Nodes/Shapes/SVGPolyline.php
+++ b/src/Nodes/Shapes/SVGPolyline.php
@@ -10,12 +10,14 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGPolyline extends SVGPolygonalShape
 {
+    const TAG_NAME = 'polyline';
+
     /**
      * @param array[] $points Array of points (float 2-tuples).
      */
     public function __construct($points = array())
     {
-        parent::__construct('polyline', $points);
+        parent::__construct($points);
     }
 
     public function rasterize(SVGRasterizer $rasterizer)

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -11,6 +11,8 @@ use JangoBrick\SVG\Rasterization\SVGRasterizer;
  */
 class SVGRect extends SVGNode
 {
+    const TAG_NAME = 'rect';
+
     /**
      * @var string $x      The x coordinate of the upper left corner.
      * @var string $y      The y coordinate of the upper left corner.
@@ -27,7 +29,7 @@ class SVGRect extends SVGNode
      */
     public function __construct($x, $y, $width, $height)
     {
-        parent::__construct('rect');
+        parent::__construct();
 
         $this->x      = $x;
         $this->y      = $y;

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -14,51 +14,29 @@ class SVGRect extends SVGNode
     const TAG_NAME = 'rect';
 
     /**
-     * @var string $x      The x coordinate of the upper left corner.
-     * @var string $y      The y coordinate of the upper left corner.
-     * @var string $width  The width.
-     * @var string $height The height.
+     * @param string|null $x      The x coordinate of the upper left corner.
+     * @param string|null $y      The y coordinate of the upper left corner.
+     * @param string|null $width  The width.
+     * @param string|null $height The height.
      */
-    protected $x, $y, $width, $height;
-
-    /**
-     * @param string $x      The x coordinate of the upper left corner.
-     * @param string $y      The y coordinate of the upper left corner.
-     * @param string $width  The width.
-     * @param string $height The height.
-     */
-    public function __construct($x, $y, $width, $height)
+    public function __construct($x = null, $y = null, $width = null, $height = null)
     {
         parent::__construct();
 
-        $this->x      = $x;
-        $this->y      = $y;
-        $this->width  = $width;
-        $this->height = $height;
-    }
-
-    /**
-     * @inheritDoc
-     * @SuppressWarnings("NPath")
-     */
-    public static function constructFromAttributes($attrs)
-    {
-        $x = isset($attrs['x']) ? $attrs['x'] : 0;
-        $y = isset($attrs['y']) ? $attrs['y'] : 0;
-        $w = isset($attrs['width']) ? $attrs['width'] : 0;
-        $h = isset($attrs['height']) ? $attrs['height'] : 0;
-
-        return new self($x, $y, $w, $h);
+        $this->setAttributeOptional('x', $x);
+        $this->setAttributeOptional('y', $y);
+        $this->setAttributeOptional('width', $width);
+        $this->setAttributeOptional('height', $height);
     }
 
 
 
     /**
-     * @return The x coordinate of the upper left corner.
+     * @return string The x coordinate of the upper left corner.
      */
     public function getX()
     {
-        return $this->x;
+        return $this->getAttribute('x');
     }
 
     /**
@@ -70,16 +48,15 @@ class SVGRect extends SVGNode
      */
     public function setX($x)
     {
-        $this->x = $x;
-        return $this;
+        return $this->setAttribute('x', $x);
     }
 
     /**
-     * @return The y coordinate of the upper left corner.
+     * @return string The y coordinate of the upper left corner.
      */
     public function getY()
     {
-        return $this->y;
+        return $this->getAttribute('y');
     }
 
     /**
@@ -91,18 +68,17 @@ class SVGRect extends SVGNode
      */
     public function setY($y)
     {
-        $this->y = $y;
-        return $this;
+        return $this->setAttribute('y', $y);
     }
 
 
 
     /**
-     * @return The width.
+     * @return string The width.
      */
     public function getWidth()
     {
-        return $this->width;
+        return $this->getAttribute('width');
     }
 
     /**
@@ -112,16 +88,15 @@ class SVGRect extends SVGNode
      */
     public function setWidth($width)
     {
-        $this->width = $width;
-        return $this;
+        return $this->setAttribute('width', $width);
     }
 
     /**
-     * @return The height.
+     * @return string The height.
      */
     public function getHeight()
     {
-        return $this->height;
+        return $this->getAttribute('height');
     }
 
     /**
@@ -131,22 +106,7 @@ class SVGRect extends SVGNode
      */
     public function setHeight($height)
     {
-        $this->height = $height;
-        return $this;
-    }
-
-
-
-    public function getSerializableAttributes()
-    {
-        $attrs = parent::getSerializableAttributes();
-
-        $attrs['x'] = $this->x;
-        $attrs['y'] = $this->y;
-        $attrs['width'] = $this->width;
-        $attrs['height'] = $this->height;
-
-        return $attrs;
+        return $this->setAttribute('width', $height);
     }
 
 
@@ -154,10 +114,10 @@ class SVGRect extends SVGNode
     public function rasterize(SVGRasterizer $rasterizer)
     {
         $rasterizer->render('rect', array(
-            'x'         => $this->x,
-            'y'         => $this->y,
-            'width'     => $this->width,
-            'height'    => $this->height,
+            'x'         => $this->getX(),
+            'y'         => $this->getY(),
+            'width'     => $this->getWidth(),
+            'height'    => $this->getHeight(),
         ), $this);
     }
 }

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -10,6 +10,8 @@ use JangoBrick\SVG\Nodes\SVGNodeContainer;
  */
 class SVGDocumentFragment extends SVGNodeContainer
 {
+    const TAG_NAME = 'svg';
+
     /** @var mixed[] $initialStyles A map of style keys to their defaults. */
     private static $initialStyles = array(
         'fill'          => '#000000',
@@ -38,7 +40,7 @@ class SVGDocumentFragment extends SVGNodeContainer
      */
     public function __construct($root = false, $width = '100%', $height = '100%', array $namespaces = array())
     {
-        parent::__construct('svg');
+        parent::__construct();
 
         $this->root = (bool) $root;
         $this->namespaces = $namespaces;

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -20,46 +20,30 @@ class SVGDocumentFragment extends SVGNodeContainer
         'opacity'       => 1,
     );
 
-    /**
-     * @var float  $x      The x position, if not root.
-     * @var float  $y      The y position, if not root.
-     * @var string $width  The declared width.
-     * @var string $height The declared height.
-     */
-    protected $x, $y, $width, $height;
     /** @var bool $root Whether this is the root document. */
     private $root;
     /** @var string[] $namespaces A map of custom namespaces to their URIs. */
     private $namespaces;
 
     /**
-     * @param bool     $root       Whether this is the root document.
-     * @param string   $width      The declared width.
-     * @param string   $height     The declared height.
-     * @param string[] $namespaces A map of custom namespaces to their URIs.
+     * @param bool        $root       Whether this is the root document.
+     * @param string|null $width      The declared width.
+     * @param string|null $height     The declared height.
+     * @param string[]    $namespaces A map of custom namespaces to their URIs.
      */
-    public function __construct($root = false, $width = '100%', $height = '100%', array $namespaces = array())
+    public function __construct($root = false, $width = null, $height = null, array $namespaces = array())
     {
         parent::__construct();
 
         $this->root = (bool) $root;
         $this->namespaces = $namespaces;
 
-        $this->width  = $width;
-        $this->height = $height;
+        $this->setAttributeOptional('width', $width);
+        $this->setAttributeOptional('height', $height);
 
         foreach (self::$initialStyles as $style => $value) {
             $this->setStyle($style, $value);
         }
-    }
-
-    /**
-     * @inheritDoc
-     * @SuppressWarnings("unused")
-     */
-    public static function constructFromAttributes($attrs)
-    {
-        return new self(false);
     }
 
     /**
@@ -77,7 +61,7 @@ class SVGDocumentFragment extends SVGNodeContainer
      */
     public function getWidth()
     {
-        return $this->width;
+        return $this->getAttribute('width');
     }
 
     /**
@@ -89,8 +73,7 @@ class SVGDocumentFragment extends SVGNodeContainer
      */
     public function setWidth($width)
     {
-        $this->width = $width;
-        return $this;
+        return $this->setAttribute('width', $width);
     }
 
     /**
@@ -98,7 +81,7 @@ class SVGDocumentFragment extends SVGNodeContainer
      */
     public function getHeight()
     {
-        return $this->height;
+        return $this->getAttribute('height');
     }
 
     /**
@@ -110,8 +93,7 @@ class SVGDocumentFragment extends SVGNodeContainer
      */
     public function setHeight($height)
     {
-        $this->height = $height;
-        return $this;
+        return $this->setAttribute('height', $height);
     }
 
 
@@ -128,20 +110,13 @@ class SVGDocumentFragment extends SVGNodeContainer
                 }
                 $attrs[$namespace] = $uri;
             }
-        } else {
-            if ($this->x != 0) {
-                $attrs['x'] = $this->x;
-            }
-            if ($this->y != 0) {
-                $attrs['x'] = $this->y;
-            }
         }
 
-        if ($this->width != '100%') {
-            $attrs['width'] = $this->width;
+        if (isset($attrs['width']) && $attrs['width'] === '100%') {
+            unset($attrs['width']);
         }
-        if ($this->height != '100%') {
-            $attrs['height'] = $this->height;
+        if (isset($attrs['height']) && $attrs['height'] === '100%') {
+            unset($attrs['height']);
         }
 
         return $attrs;

--- a/src/Nodes/Structures/SVGGroup.php
+++ b/src/Nodes/Structures/SVGGroup.php
@@ -9,9 +9,11 @@ use JangoBrick\SVG\Nodes\SVGNodeContainer;
  */
 class SVGGroup extends SVGNodeContainer
 {
+    const TAG_NAME = 'g';
+
     public function __construct()
     {
-        parent::__construct('g');
+        parent::__construct();
     }
 
     /**

--- a/src/Nodes/Structures/SVGGroup.php
+++ b/src/Nodes/Structures/SVGGroup.php
@@ -15,13 +15,4 @@ class SVGGroup extends SVGNodeContainer
     {
         parent::__construct();
     }
-
-    /**
-     * @inheritDoc
-     * @SuppressWarnings("unused")
-     */
-    public static function constructFromAttributes($attrs)
-    {
-        return new self();
-    }
 }

--- a/src/Reading/SVGReader.php
+++ b/src/Reading/SVGReader.php
@@ -29,16 +29,6 @@ class SVGReader
         'path'      => 'JangoBrick\SVG\Nodes\Shapes\SVGPath',
     );
     /**
-    * @var string[] $ignoredAttributes Ignored attribs dealt with elsewhere.
-    */
-    private static $ignoredAttributes = array(
-        'x', 'y', 'width', 'height',
-        'x1', 'y1', 'x2', 'y2',
-        'cx', 'cy', 'r', 'rx', 'ry',
-        'points', 'd',
-        'style',
-    );
-    /**
      * @var string[] @styleAttributes Attributes to be interpreted as styles.
      * List comes from https://www.w3.org/TR/SVG/styling.html.
      */
@@ -154,11 +144,9 @@ class SVGReader
      *
      * Since styles in SVG can also be expressed with attributes, this method
      * checks the name of each attribute and, if it matches that of a style,
-     * applies it as a style instead.
-     * For a list of attributes considered styles, see self::$styleAttributes.
+     * applies it as a style instead. The actual 'style' attribute is ignored.
      *
-     * Some names are ignored (e.g. 'style' or shape properties like 'points').
-     * For a list of ignored attributes, see self::$ignoredAttributes.
+     * For a list of attributes considered styles, see self::$styleAttributes.
      *
      * @param SVGNode           $node The node to apply the attributes to.
      * @param \SimpleXMLElement $xml  The attribute source.
@@ -168,7 +156,7 @@ class SVGReader
     private function applyAttributes(SVGNode $node, \SimpleXMLElement $xml)
     {
         foreach ($xml->attributes() as $key => $value) {
-            if (in_array($key, self::$ignoredAttributes)) {
+            if ($key === 'style') {
                 continue;
             }
             if (in_array($key, self::$styleAttributes)) {

--- a/tests/SVGImageTest.php
+++ b/tests/SVGImageTest.php
@@ -9,7 +9,7 @@ class SVGImageTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->xml  = '<?xml version="1.0" encoding="utf-8"?>';
-        $this->xml .= '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">';
+        $this->xml .= '<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg">';
         $this->xml .= '</svg>';
     }
 


### PR DESCRIPTION
Most nodes now use the central `SVGNode::attributes` for storing their special properties, e.g. SVGRect doesn't use separate x, y, width and height properties, but instead just has the respective getters and setters act as covers for `getAttribute()` and `setAttribute()`.
Additionally, tag names are stored in new 'TAG_NAME' constants for every SVGNode subclass. They are used directly by SVGNode, and so passing the names via the super constructor has become unnecessary.

This has a multitude of benefits:
* Every attribute is serialized automatically.
* The "special" properties aren't so special any more; they are treated like every other, with support for `getAttribute(...)` and so on.

Moreover, SVGNode subclasses need not override `constructFromAttributes(...)` as before, provided that their constructor matches the general expectations. If not, they can still override (SVGPolygonalShape does this for point array construction).