### PR TITLE
Add viewBox support to rasterization

### DIFF
--- a/src/Rasterization/Renderers/SVGEllipseRenderer.php
+++ b/src/Rasterization/Renderers/SVGEllipseRenderer.php
@@ -18,8 +18,8 @@ class SVGEllipseRenderer extends SVGRenderer
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         return array(
-            'cx'        => self::prepareLengthX($options['cx'], $rasterizer),
-            'cy'        => self::prepareLengthY($options['cy'], $rasterizer),
+            'cx'        => self::prepareLengthX($options['cx'], $rasterizer) + $rasterizer->getOffsetX(),
+            'cy'        => self::prepareLengthY($options['cy'], $rasterizer) + $rasterizer->getOffsetY(),
             'width'     => self::prepareLengthX($options['rx'], $rasterizer) * 2,
             'height'    => self::prepareLengthY($options['ry'], $rasterizer) * 2,
         );

--- a/src/Rasterization/Renderers/SVGLineRenderer.php
+++ b/src/Rasterization/Renderers/SVGLineRenderer.php
@@ -17,11 +17,14 @@ class SVGLineRenderer extends SVGRenderer
 {
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
+        $offsetX = $rasterizer->getOffsetX();
+        $offsetY = $rasterizer->getOffsetY();
+
         return array(
-            'x1' => self::prepareLengthX($options['x1'], $rasterizer),
-            'y1' => self::prepareLengthY($options['y1'], $rasterizer),
-            'x2' => self::prepareLengthX($options['x2'], $rasterizer),
-            'y2' => self::prepareLengthY($options['y2'], $rasterizer),
+            'x1' => self::prepareLengthX($options['x1'], $rasterizer) + $offsetX,
+            'y1' => self::prepareLengthY($options['y1'], $rasterizer) + $offsetY,
+            'x2' => self::prepareLengthX($options['x2'], $rasterizer) + $offsetX,
+            'y2' => self::prepareLengthY($options['y2'], $rasterizer) + $offsetY,
         );
     }
 

--- a/src/Rasterization/Renderers/SVGPolygonRenderer.php
+++ b/src/Rasterization/Renderers/SVGPolygonRenderer.php
@@ -19,10 +19,13 @@ class SVGPolygonRenderer extends SVGRenderer
         $scaleX = $rasterizer->getScaleX();
         $scaleY = $rasterizer->getScaleY();
 
+        $offsetX = $rasterizer->getOffsetX();
+        $offsetY = $rasterizer->getOffsetY();
+
         $points = array();
         foreach($options['points'] as $point) {
-            $points[] = $point[0] * $scaleX;
-            $points[] = $point[1] * $scaleY;
+            $points[] = $point[0] * $scaleX + $offsetX;
+            $points[] = $point[1] * $scaleY + $offsetY;
         }
 
         return array(

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -17,8 +17,8 @@ class SVGRectRenderer extends SVGRenderer
 {
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
-        $x1 = self::prepareLengthX($options['x'], $rasterizer);
-        $y1 = self::prepareLengthY($options['y'], $rasterizer);
+        $x1 = self::prepareLengthX($options['x'], $rasterizer) + $rasterizer->getOffsetX();
+        $y1 = self::prepareLengthY($options['y'], $rasterizer) + $rasterizer->getOffsetY();
         $w  = self::prepareLengthX($options['width'], $rasterizer);
         $h  = self::prepareLengthY($options['height'], $rasterizer);
 

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -233,6 +233,34 @@ class SVGRasterizer
 
 
     /**
+     * @return float The amount by which renderers must offset their drawings
+     *               on the x-axis (not to be scaled).
+     */
+    public function getOffsetX()
+    {
+        if ($this->viewBox && !empty($this->viewBox)) {
+            $scale = $this->height / $this->viewBox[2];
+            return -($this->viewBox[0] * $scale);
+        }
+        return 0;
+    }
+
+    /**
+     * @return float The amount by which renderers must offset their drawings
+     *               on the y-axis (not to be scaled).
+     */
+    public function getOffsetY()
+    {
+        if ($this->viewBox && !empty($this->viewBox)) {
+            $scale = $this->height / $this->viewBox[3];
+            return -($this->viewBox[1] * $scale);
+        }
+        return 0;
+    }
+
+
+
+    /**
      * @return resource The GD image resource this rasterizer is operating on.
      */
     public function getImage()

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -29,34 +29,33 @@ class SVGRasterizer
      */
     private $docWidth, $docHeight;
     /**
+     * @var float[] The document's viewBox (x, y, w, h).
+     */
+    private $viewBox;
+    /**
      * @var int $width  The output image width, in pixels.
      * @var int $height The output image height, in pixels.
      */
     private $width, $height;
-    /**
-     * @var float $scaleX The factor by which output is scaled on the x-axis.
-     * @var float $scaleY The factor by which output is scaled on the y-axis.
-     */
-    private $scaleX, $scaleY;
     /** @var resource $outImage The output image as a GD resource. */
     private $outImage;
 
     /**
-     * @param int $docWidth  The original SVG document width, in pixels.
-     * @param int $docHeight The original SVG document height, in pixels.
-     * @param int $width     The output image width, in pixels.
-     * @param int $height    The output image height, in pixels.
+     * @param int $docWidth    The original SVG document width, in pixels.
+     * @param int $docHeight   The original SVG document height, in pixels.
+     * @param float[] $viewBox The document's viewBox.
+     * @param int $width       The output image width, in pixels.
+     * @param int $height      The output image height, in pixels.
      */
-    public function __construct($docWidth, $docHeight, $width, $height)
+    public function __construct($docWidth, $docHeight, $viewBox, $width, $height)
     {
         $this->docWidth  = $docWidth;
         $this->docHeight = $docHeight;
 
+        $this->viewBox = $viewBox;
+
         $this->width  = $width;
         $this->height = $height;
-
-        $this->scaleX = $width / $docWidth;
-        $this->scaleY = $height / $docHeight;
 
         $this->outImage = self::createImage($width, $height);
 
@@ -212,7 +211,11 @@ class SVGRasterizer
      */
     public function getScaleX()
     {
-        return $this->scaleX;
+        $vbWidth = $this->docWidth;
+        if ($this->viewBox && !empty($this->viewBox)) {
+            $vbWidth = $this->viewBox[2];
+        }
+        return $this->width / $vbWidth;
     }
 
     /**
@@ -220,7 +223,11 @@ class SVGRasterizer
      */
     public function getScaleY()
     {
-        return $this->scaleY;
+        $vbHeight = $this->docHeight;
+        if ($this->viewBox && !empty($this->viewBox)) {
+            $vbHeight = $this->viewBox[3];
+        }
+        return $this->height / $vbHeight;
     }
 
 

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -63,6 +63,8 @@ class SVGRasterizer
         self::createDependencies();
     }
 
+
+
     /**
      * Sets up a new truecolor GD image resource with the given dimensions.
      *
@@ -83,6 +85,34 @@ class SVGRasterizer
         imagefill($img, 0, 0, 0x7F000000);
 
         return $img;
+    }
+
+    /**
+     * Applies a clip to the given image. In other words, ignores everything
+     * outside the given rectangle. Returns a new image.
+     *
+     * @param resource $img The image resource to clip.
+     * @param int      $x1  The rect's start x coordinate.
+     * @param int      $y1  The rect's start y coordinate.
+     * @param int      $x2  The rect's end x coordinate.
+     * @param int      $y2  The rect's end y coordinate.
+     *
+     * @return resource A new image that is clipped.
+     */
+    private static function clipImage($img, $x1, $y1, $x2, $y2)
+    {
+        $imgWidth  = imagesx($img);
+        $imgHeight = imagesy($img);
+
+        $x1 = min(max($x1, 0), $imgWidth);
+        $y1 = min(max($y1, 0), $imgHeight);
+        $x2 = min(max($x2, 0), $imgWidth);
+        $y2 = min(max($y2, 0), $imgHeight);
+
+        $newImg = self::createImage($imgWidth, $imgHeight);
+        imagecopy($newImg, $img, $x1, $y1, $x1, $y1, ($x2 - $x1), ($y2 - $y1));
+
+        return $newImg;
     }
 
 
@@ -258,6 +288,25 @@ class SVGRasterizer
     }
 
 
+
+    /**
+     * Applies final processing steps to the output image. It is then returned.
+     *
+     * @return resource The GD image resource this rasterizer is operating on.
+     */
+    public function finish()
+    {
+        if (empty($this->viewBox)) {
+            return $this->outImage;
+        }
+
+        $width  = $this->getDocumentWidth();
+        $height = $this->getDocumentHeight();
+
+        $this->outImage = self::clipImage($this->outImage, 0, 0, $width, $height);
+
+        return $this->outImage;
+    }
 
     /**
      * @return resource The GD image resource this rasterizer is operating on.

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -206,7 +206,7 @@ class SVGRasterizer
      */
     public function getDocumentWidth()
     {
-        return SVG::convertUnit($this->docWidth, $this->width);
+        return SVG::convertUnit($this->docWidth ?: '100%', $this->width);
     }
 
     /**
@@ -214,7 +214,7 @@ class SVGRasterizer
      */
     public function getDocumentHeight()
     {
-        return SVG::convertUnit($this->docHeight, $this->height);
+        return SVG::convertUnit($this->docHeight ?: '100%', $this->height);
     }
 
 

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -211,11 +211,10 @@ class SVGRasterizer
      */
     public function getScaleX()
     {
-        $vbWidth = $this->docWidth;
-        if ($this->viewBox && !empty($this->viewBox)) {
-            $vbWidth = $this->viewBox[2];
+        if (!empty($this->viewBox)) {
+            return $this->getDocumentWidth() / $this->viewBox[2];
         }
-        return $this->width / $vbWidth;
+        return $this->width / $this->getDocumentWidth();
     }
 
     /**
@@ -223,11 +222,10 @@ class SVGRasterizer
      */
     public function getScaleY()
     {
-        $vbHeight = $this->docHeight;
-        if ($this->viewBox && !empty($this->viewBox)) {
-            $vbHeight = $this->viewBox[3];
+        if (!empty($this->viewBox)) {
+            return $this->getDocumentHeight() / $this->viewBox[3];
         }
-        return $this->height / $vbHeight;
+        return $this->height / $this->getDocumentHeight();
     }
 
 
@@ -238,8 +236,8 @@ class SVGRasterizer
      */
     public function getOffsetX()
     {
-        if ($this->viewBox && !empty($this->viewBox)) {
-            $scale = $this->height / $this->viewBox[2];
+        if (!empty($this->viewBox)) {
+            $scale = $this->getDocumentWidth() / $this->viewBox[2];
             return -($this->viewBox[0] * $scale);
         }
         return 0;
@@ -251,8 +249,8 @@ class SVGRasterizer
      */
     public function getOffsetY()
     {
-        if ($this->viewBox && !empty($this->viewBox)) {
-            $scale = $this->height / $this->viewBox[3];
+        if (!empty($this->viewBox)) {
+            $scale = $this->getDocumentHeight() / $this->viewBox[3];
             return -($this->viewBox[1] * $scale);
         }
         return 0;

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -2,6 +2,7 @@
 
 namespace JangoBrick\SVG\Rasterization;
 
+use JangoBrick\SVG\SVG;
 use JangoBrick\SVG\Nodes\SVGNode;
 
 /**
@@ -175,7 +176,7 @@ class SVGRasterizer
      */
     public function getDocumentWidth()
     {
-        return $this->docWidth;
+        return SVG::convertUnit($this->docWidth, $this->width);
     }
 
     /**
@@ -183,7 +184,7 @@ class SVGRasterizer
      */
     public function getDocumentHeight()
     {
-        return $this->docHeight;
+        return SVG::convertUnit($this->docHeight, $this->height);
     }
 
 

--- a/src/SVGImage.php
+++ b/src/SVGImage.php
@@ -55,7 +55,13 @@ class SVGImage
         $docWidth  = $this->document->getWidth();
         $docHeight = $this->document->getHeight();
 
-        $rasterizer = new SVGRasterizer($docWidth, $docHeight, $width, $height);
+        $viewBox     = null;
+        $viewBoxAttr = $this->document->getAttribute('viewBox');
+        if ($viewBoxAttr) {
+            $viewBox = array_map('floatval', explode(' ', $viewBoxAttr));
+        }
+
+        $rasterizer = new SVGRasterizer($docWidth, $docHeight, $viewBox, $width, $height);
         $this->document->rasterize($rasterizer);
 
         return $rasterizer->getImage();

--- a/src/SVGImage.php
+++ b/src/SVGImage.php
@@ -64,7 +64,7 @@ class SVGImage
         $rasterizer = new SVGRasterizer($docWidth, $docHeight, $viewBox, $width, $height);
         $this->document->rasterize($rasterizer);
 
-        return $rasterizer->getImage();
+        return $rasterizer->finish();
     }
 
     /**


### PR DESCRIPTION
This closes #20. `preserveAspectRatio` is not yet supported, but `viewBox` itself behaves correctly both with and without accompanying `width`/`height` attributes.