### PR TITLE
Update SVGPolygonalShape.php, trimm points attribute from trailing spaces

### DIFF
--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -28,7 +28,7 @@ abstract class SVGPolygonalShape extends SVGNode
         $points = array();
 
         if (isset($attrs['points'])) {
-            $coords = preg_split('/[\s,]+/', $attrs['points']);
+            $coords = preg_split('/[\s,]+/', trim($attrs['points']));
             for ($i = 0, $n = count($coords); $i < $n; $i += 2) {
                 $points[] = array(
                     floatval($coords[$i]),


### PR DESCRIPTION
Sometimes $attrs['points'] contain trailing spaces in the end or beginning of string which results to an error (undefined index). Trimmed those spaces to solve the issue.